### PR TITLE
Fix time column in PPPoE client sessions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.9.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1 // indirect
+	github.com/xhit/go-str2duration/v2 v2.0.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/protobuf v1.24.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -309,6 +309,9 @@ github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/xhit/go-str2duration v1.2.0 h1:BcV5u025cITWxEQKGWr1URRzrcXtu7uk8+luz3Yuhwc=
+github.com/xhit/go-str2duration/v2 v2.0.0 h1:uFtk6FWB375bP7ewQl+/1wBcn840GPhnySOdcz/okPE=
+github.com/xhit/go-str2duration/v2 v2.0.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=

--- a/infrastructure/cmd/parser.go
+++ b/infrastructure/cmd/parser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/alecthomas/units"
 	"github.com/chitoku-k/edgerouter-exporter/service"
 	"github.com/sirupsen/logrus"
+	str2duration "github.com/xhit/go-str2duration/v2"
 )
 
 var (
@@ -271,7 +272,7 @@ func parseTime(key, value string) *time.Time {
 }
 
 func parseDuration(key, value string) *time.Duration {
-	d, err := time.ParseDuration(value)
+	d, err := str2duration.ParseDuration(value)
 	if err != nil {
 		logrus.Infof(`Cannot parse "%s" to a duration (key: "%s"): %v`, value, key, err)
 		return nil

--- a/infrastructure/cmd/parser_test.go
+++ b/infrastructure/cmd/parser_test.go
@@ -396,7 +396,7 @@ var _ = Describe("Parser", func() {
 					"User       Time      Proto Iface   Remote IP       TX pkt/byte   RX pkt/byte",
 					"---------- --------- ----- -----   --------------- ------ ------ ------ ------",
 					"user01     01h02m03s PPPoE pppoe0  192.0.2.255   384  34.8K   1.2K  58.2K",
-					"user02     04h05m06s PPPoE pppoe1  198.51.100.255   768  76.8K   2.4K 116.4K",
+					"user02     04d05h06m PPPoE pppoe1  198.51.100.255   768  76.8K   2.4K 116.4K",
 					"",
 					"Total sessions: 1",
 				})
@@ -414,7 +414,7 @@ var _ = Describe("Parser", func() {
 					},
 					{
 						User:            "user02",
-						Time:            parseDuration("14706s"),
+						Time:            parseDuration("363960s"),
 						Protocol:        "PPPoE",
 						Interface:       "pppoe1",
 						RemoteIP:        "198.51.100.255",


### PR DESCRIPTION
The standard `ParseDuration` in `time` package does not understand `d` as a valid unit because it can cause an indeterministic behaviour where two days contain summer time switches. For the case a PPPoE client session exceeds 24 hours, it failed to parse the time as shown below:
```
Cannot parse "01d10h57m" to a duration (key: "[1]"): time: unknown unit "d" in duration "01d10h57m"
```
This PR fixes this by xhit/go-str2duration which understands `d` as 24 hours.