### PR TITLE
Add local_ip_address label on pppoe_client_session_*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "pretty_assertions",
  "prometheus-client",
  "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -930,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.76"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edde269018d33d7146dd074e5f7da6fef9b0a957507454c867caa0852c560a9a"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa 1.0.1",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ version = "0.15.0"
 version = "1.0.136"
 features = ["derive"]
 
+[dependencies.serde_json]
+version = "1.0.78"
+
 [dependencies.tokio]
 version = "1.16.1"
 features = ["macros", "net", "process", "rt-multi-thread"]

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ export TLS_CERT=/path/to/tls/cert
 export TLS_KEY=/path/to/tls/key
 
 # Op command (optional)
+export IP_COMMAND=/bin/ip
 export OP_COMMAND=/opt/vyatta/bin/vyatta-op-cmd-wrapper
 export OP_DDNS_COMMAND=/opt/vyatta/bin/sudo-users/vyatta-op-dynamic-dns.pl
 export VTYSH_COMMAND=/opt/vyatta/sbin/ubnt_vtysh
@@ -167,19 +168,19 @@ edgerouter_load_balancer_run_fail_total{group_name="WAN_FAILOVER",interface_name
 ```
 # HELP edgerouter_pppoe_client_session_receive_bytes_total Total receive bytes for PPPoE client session
 # TYPE edgerouter_pppoe_client_session_receive_bytes_total gauge
-edgerouter_pppoe_client_session_receive_bytes_total{interface_name="pppoe0",ip_address="192.0.2.255",protocol="PPPoE",user="user01"} 79360
+edgerouter_pppoe_client_session_receive_bytes_total{interface_name="pppoe0",ip_address="192.0.2.255",local_ip_address="203.0.113.1",protocol="PPPoE",user="user01"} 79360
 # HELP edgerouter_pppoe_client_session_receive_packets_total Total receive packets for PPPoE client session
 # TYPE edgerouter_pppoe_client_session_receive_packets_total gauge
-edgerouter_pppoe_client_session_receive_packets_total{interface_name="pppoe0",ip_address="192.0.2.255",protocol="PPPoE",user="user01"} 1638
+edgerouter_pppoe_client_session_receive_packets_total{interface_name="pppoe0",ip_address="192.0.2.255",local_ip_address="203.0.113.1",protocol="PPPoE",user="user01"} 1638
 # HELP edgerouter_pppoe_client_session_seconds_total Total seconds for PPPoE client session
 # TYPE edgerouter_pppoe_client_session_seconds_total gauge
-edgerouter_pppoe_client_session_seconds_total{interface_name="pppoe0",ip_address="192.0.2.255",protocol="PPPoE",user="user01"} 18975
+edgerouter_pppoe_client_session_seconds_total{interface_name="pppoe0",ip_address="192.0.2.255",local_ip_address="203.0.113.1",protocol="PPPoE",user="user01"} 18975
 # HELP edgerouter_pppoe_client_session_transmit_bytes_total Total transmit bytes for PPPoE client session
 # TYPE edgerouter_pppoe_client_session_transmit_bytes_total gauge
-edgerouter_pppoe_client_session_transmit_bytes_total{interface_name="pppoe0",ip_address="192.0.2.255",protocol="PPPoE",user="user01"} 39116
+edgerouter_pppoe_client_session_transmit_bytes_total{interface_name="pppoe0",ip_address="192.0.2.255",local_ip_address="203.0.113.1",protocol="PPPoE",user="user01"} 39116
 # HELP edgerouter_pppoe_client_session_transmit_packets_total Total transmit packets for PPPoE client session
 # TYPE edgerouter_pppoe_client_session_transmit_packets_total gauge
-edgerouter_pppoe_client_session_transmit_packets_total{interface_name="pppoe0",ip_address="192.0.2.255",protocol="PPPoE",user="user01"} 412
+edgerouter_pppoe_client_session_transmit_packets_total{interface_name="pppoe0",ip_address="192.0.2.255",local_ip_address="203.0.113.1",protocol="PPPoE",user="user01"} 412
 ```
 
 ### Spec

--- a/src/application/metrics/bgp.rs
+++ b/src/application/metrics/bgp.rs
@@ -31,7 +31,7 @@ impl From<BGPNeighbor> for BGPNeighborLabel {
 }
 
 impl Collector for (BGPStatusResult, BGPStatusResult) {
-    fn collect(self, registry: &mut Registry) {
+    fn collect(self, registry: &mut Registry, _: ()) {
         let bgp_msg_rcv = Family::<BGPNeighborLabel, Gauge>::default();
         registry.register(
             "edgerouter_bgp_message_received_total",

--- a/src/application/metrics/ddns.rs
+++ b/src/application/metrics/ddns.rs
@@ -31,7 +31,7 @@ impl From<DdnsStatus> for DdnsStatusLabel {
 }
 
 impl Collector for DdnsStatusResult {
-    fn collect(self, registry: &mut Registry) {
+    fn collect(self, registry: &mut Registry, _: ()) {
         let ddns_status = Family::<DdnsStatusLabel, Gauge>::default();
         registry.register(
             "edgerouter_dynamic_dns_status",

--- a/src/application/metrics/load_balance.rs
+++ b/src/application/metrics/load_balance.rs
@@ -65,7 +65,7 @@ impl LoadBalanceHealthLabel {
 }
 
 impl Collector for LoadBalanceGroupResult {
-    fn collect(self, registry: &mut Registry) {
+    fn collect(self, registry: &mut Registry, _: ()) {
         let load_balancer_health = Family::<LoadBalanceHealthLabel, Gauge>::default();
         registry.register(
             "edgerouter_load_balancer_health",

--- a/src/application/metrics/version.rs
+++ b/src/application/metrics/version.rs
@@ -28,7 +28,7 @@ impl From<Version> for VersionLabel {
 }
 
 impl Collector for VersionResult {
-    fn collect(self, registry: &mut Registry) {
+    fn collect(self, registry: &mut Registry, _: ()) {
         let info = Family::<VersionLabel, Gauge>::default();
         registry.register(
             "edgerouter_info",

--- a/src/di/container.rs
+++ b/src/di/container.rs
@@ -7,6 +7,7 @@ use crate::{
             parser::{
                 bgp::BGPParser,
                 ddns::DdnsParser,
+                interface::InterfaceParser,
                 load_balance::LoadBalanceParser,
                 pppoe::PPPoEParser,
                 version::VersionParser,
@@ -14,6 +15,7 @@ use crate::{
             runner::{
                 bgp::BGPRunner,
                 ddns::DdnsRunner,
+                interface::InterfaceRunner,
                 load_balance::LoadBalanceRunner,
                 pppoe::PPPoERunner,
                 version::VersionRunner,
@@ -43,6 +45,7 @@ impl Application {
             MetricsHandler::new(
                 BGPRunner::new(&config.vtysh_command, CommandExecutor, BGPParser),
                 DdnsRunner::new(&config.op_ddns_command, CommandExecutor, DdnsParser),
+                InterfaceRunner::new(&config.ip_command, CommandExecutor, InterfaceParser),
                 LoadBalanceRunner::new(&config.op_command, CommandExecutor, LoadBalanceParser),
                 PPPoERunner::new(&config.op_command, CommandExecutor, PPPoEParser),
                 VersionRunner::new(&config.op_command, CommandExecutor, VersionParser),

--- a/src/domain/interface.rs
+++ b/src/domain/interface.rs
@@ -1,0 +1,37 @@
+use std::net::IpAddr;
+
+use serde::Deserialize;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Interface {
+    pub ifindex: u32,
+    pub ifname: String,
+    pub link: Option<String>,
+    pub flags: Vec<String>,
+    pub mtu: u32,
+    pub qdisc: String,
+    pub operstate: String,
+    pub group: String,
+    pub txqlen: u32,
+    pub link_type: String,
+    pub address: Option<String>,
+    pub link_pointtopoint: Option<bool>,
+    pub broadcast: Option<String>,
+    pub addr_info: Vec<AddrInfo>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct AddrInfo {
+    pub family: String,
+    pub local: IpAddr,
+    pub address: Option<IpAddr>,
+    pub prefixlen: u32,
+    pub broadcast: Option<IpAddr>,
+    pub scope: String,
+    pub dynamic: Option<bool>,
+    pub mngtmpaddr: Option<bool>,
+    pub noprefixroute: Option<bool>,
+    pub label: Option<String>,
+    pub valid_life_time: u64,
+    pub preferred_life_time: u64,
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,5 +1,6 @@
 pub mod bgp;
 pub mod ddns;
+pub mod interface;
 pub mod load_balance;
 pub mod pppoe;
 pub mod version;

--- a/src/infrastructure/cmd/parser/interface.rs
+++ b/src/infrastructure/cmd/parser/interface.rs
@@ -1,0 +1,126 @@
+use crate::{
+    domain::interface::Interface,
+    infrastructure::cmd::parser::Parser,
+    service::interface::InterfaceResult,
+};
+
+#[derive(Clone)]
+pub struct InterfaceParser;
+
+impl Parser for InterfaceParser {
+    type Item = InterfaceResult;
+
+    fn parse(&self, input: &str) -> anyhow::Result<Self::Item> {
+        parse_interface(input)
+    }
+}
+
+fn parse_interface(input: &str) -> anyhow::Result<Vec<Interface>> {
+    let interfaces = serde_json::from_str(input)?;
+    Ok(interfaces)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{Ipv4Addr, Ipv6Addr, IpAddr};
+
+    use indoc::indoc;
+    use pretty_assertions::assert_eq;
+
+    use crate::domain::interface::AddrInfo;
+
+    use super::*;
+
+    #[test]
+    fn interfaces() {
+        let parser = InterfaceParser;
+        let input = indoc! {r#"
+            [{
+                    "ifindex": 1,
+                    "ifname": "lo",
+                    "flags": ["LOOPBACK","UP","LOWER_UP"],
+                    "mtu": 65536,
+                    "qdisc": "noqueue",
+                    "operstate": "UNKNOWN",
+                    "group": "default",
+                    "txqlen": 1000,
+                    "link_type": "loopback",
+                    "address": "00:00:00:00:00:00",
+                    "broadcast": "00:00:00:00:00:00",
+                    "addr_info": [{
+                            "family": "inet",
+                            "local": "127.0.0.1",
+                            "prefixlen": 8,
+                            "scope": "host",
+                            "label": "lo",
+                            "valid_life_time": 4294967295,
+                            "preferred_life_time": 4294967295
+                        },{
+                            "family": "inet6",
+                            "local": "::1",
+                            "prefixlen": 128,
+                            "scope": "host",
+                            "valid_life_time": 4294967295,
+                            "preferred_life_time": 4294967295
+                        }]
+                }
+            ]
+        "#};
+
+        let actual = parser.parse(input);
+        assert!(actual.is_ok());
+
+        let actual = actual.unwrap();
+        assert_eq!(actual, vec![
+            Interface {
+                ifindex: 1,
+                ifname: "lo".to_string(),
+                link: None,
+                flags: vec![
+                    "LOOPBACK".to_string(),
+                    "UP".to_string(),
+                    "LOWER_UP".to_string(),
+                ],
+                mtu: 65536,
+                qdisc: "noqueue".to_string(),
+                operstate: "UNKNOWN".to_string(),
+                group: "default".to_string(),
+                txqlen: 1000,
+                link_type: "loopback".to_string(),
+                address: Some("00:00:00:00:00:00".to_string()),
+                link_pointtopoint: None,
+                broadcast: Some("00:00:00:00:00:00".to_string()),
+                addr_info: vec![
+                    AddrInfo {
+                        family: "inet".to_string(),
+                        local: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                        address: None,
+                        prefixlen: 8,
+                        broadcast: None,
+                        scope: "host".to_string(),
+                        dynamic: None,
+                        mngtmpaddr: None,
+                        noprefixroute: None,
+                        label: Some("lo".to_string()),
+                        valid_life_time: 4294967295,
+                        preferred_life_time: 4294967295,
+                    },
+                    AddrInfo {
+                        family: "inet6".to_string(),
+                        local: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                        address: None,
+                        prefixlen: 128,
+                        broadcast: None,
+                        scope: "host".to_string(),
+                        dynamic: None,
+                        mngtmpaddr: None,
+                        noprefixroute: None,
+                        label: None,
+                        valid_life_time: 4294967295,
+                        preferred_life_time: 4294967295,
+                    },
+                ],
+            },
+        ]);
+    }
+}

--- a/src/infrastructure/cmd/parser/mod.rs
+++ b/src/infrastructure/cmd/parser/mod.rs
@@ -11,6 +11,7 @@ use nom::{
 
 pub mod bgp;
 pub mod ddns;
+pub mod interface;
 pub mod load_balance;
 pub mod pppoe;
 pub mod version;

--- a/src/infrastructure/cmd/runner/interface.rs
+++ b/src/infrastructure/cmd/runner/interface.rs
@@ -1,0 +1,242 @@
+use async_trait::async_trait;
+
+use crate::{
+    infrastructure::{
+        cmd::{parser::Parser, runner::Executor},
+        config::env::IpCommand,
+    },
+    service::{interface::InterfaceResult, Runner},
+};
+
+#[derive(Clone)]
+pub struct InterfaceRunner<E, P>
+where
+    E: Executor + Send + Sync,
+    P: Parser<Item = InterfaceResult> + Send + Sync,
+{
+    command: IpCommand,
+    executor: E,
+    parser: P,
+}
+
+impl<E, P> InterfaceRunner<E, P>
+where
+    E: Executor + Send + Sync,
+    P: Parser<Item = InterfaceResult> + Send + Sync,
+{
+    pub fn new(command: &IpCommand, executor: E, parser: P) -> Self {
+        let command = command.to_owned();
+        Self {
+            command,
+            executor,
+            parser,
+        }
+    }
+
+    async fn interfaces(&self) -> anyhow::Result<InterfaceResult> {
+        let output = self.executor.output(&self.command, &["--json", "addr", "show"]).await?;
+        let result = self.parser.parse(&output)?;
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl<E, P> Runner for InterfaceRunner<E, P>
+where
+    E: Executor + Send + Sync,
+    P: Parser<Item = InterfaceResult> + Send + Sync,
+{
+    type Item = InterfaceResult;
+
+    async fn run(&self) -> anyhow::Result<Self::Item> {
+        self.interfaces().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+    use indoc::indoc;
+    use mockall::{mock, predicate::eq};
+    use pretty_assertions::assert_eq;
+
+    use crate::{
+        domain::interface::{AddrInfo, Interface},
+        infrastructure::cmd::runner::MockExecutor,
+    };
+
+    use super::*;
+
+    mock! {
+        InterfaceParser {}
+
+        impl Parser for InterfaceParser {
+            type Item = InterfaceResult;
+
+            fn parse(&self, input: &str) -> anyhow::Result<<Self as Parser>::Item>;
+        }
+    }
+
+    #[tokio::test]
+    async fn interfaces() {
+        let command = IpCommand::from("/bin/ip".to_string());
+        let output = indoc! {r#"
+            [{
+                    "ifindex": 1,
+                    "ifname": "lo",
+                    "flags": ["LOOPBACK","UP","LOWER_UP"],
+                    "mtu": 65536,
+                    "qdisc": "noqueue",
+                    "operstate": "UNKNOWN",
+                    "group": "default",
+                    "txqlen": 1000,
+                    "link_type": "loopback",
+                    "address": "00:00:00:00:00:00",
+                    "broadcast": "00:00:00:00:00:00",
+                    "addr_info": [{
+                            "family": "inet",
+                            "local": "127.0.0.1",
+                            "prefixlen": 8,
+                            "scope": "host",
+                            "label": "lo",
+                            "valid_life_time": 4294967295,
+                            "preferred_life_time": 4294967295
+                        },{
+                            "family": "inet6",
+                            "local": "::1",
+                            "prefixlen": 128,
+                            "scope": "host",
+                            "valid_life_time": 4294967295,
+                            "preferred_life_time": 4294967295
+                        }]
+                }
+            ]
+        "#};
+
+        let mut mock_executor = MockExecutor::new();
+        mock_executor
+            .expect_output()
+            .times(1)
+            .returning(|command, args| {
+                match (command, args) {
+                    ("/bin/ip", &["--json", "addr", "show"]) => Ok(output.to_string()),
+                    _ => panic!("unexpected args"),
+                }
+            });
+
+        let mut mock_parser = MockInterfaceParser::new();
+        mock_parser
+            .expect_parse()
+            .times(1)
+            .with(eq(output))
+            .returning(|_| Ok(vec![
+                Interface {
+                    ifindex: 1,
+                    ifname: "lo".to_string(),
+                    link: None,
+                    flags: vec![
+                        "LOOPBACK".to_string(),
+                        "UP".to_string(),
+                        "LOWER_UP".to_string(),
+                    ],
+                    mtu: 65536,
+                    qdisc: "noqueue".to_string(),
+                    operstate: "UNKNOWN".to_string(),
+                    group: "default".to_string(),
+                    txqlen: 1000,
+                    link_type: "loopback".to_string(),
+                    address: Some("00:00:00:00:00:00".to_string()),
+                    link_pointtopoint: None,
+                    broadcast: Some("00:00:00:00:00:00".to_string()),
+                    addr_info: vec![
+                        AddrInfo {
+                            family: "inet".to_string(),
+                            local: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                            address: None,
+                            prefixlen: 8,
+                            broadcast: None,
+                            scope: "host".to_string(),
+                            dynamic: None,
+                            mngtmpaddr: None,
+                            noprefixroute: None,
+                            label: Some("lo".to_string()),
+                            valid_life_time: 4294967295,
+                            preferred_life_time: 4294967295,
+                        },
+                        AddrInfo {
+                            family: "inet6".to_string(),
+                            local: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                            address: None,
+                            prefixlen: 128,
+                            broadcast: None,
+                            scope: "host".to_string(),
+                            dynamic: None,
+                            mngtmpaddr: None,
+                            noprefixroute: None,
+                            label: None,
+                            valid_life_time: 4294967295,
+                            preferred_life_time: 4294967295,
+                        },
+                    ],
+                },
+            ]));
+
+        let runner = InterfaceRunner::new(&command, mock_executor, mock_parser);
+        let actual = runner.run().await;
+        assert!(actual.is_ok());
+
+        let actual = actual.unwrap();
+        assert_eq!(actual, vec![
+            Interface {
+                ifindex: 1,
+                ifname: "lo".to_string(),
+                link: None,
+                flags: vec![
+                    "LOOPBACK".to_string(),
+                    "UP".to_string(),
+                    "LOWER_UP".to_string(),
+                ],
+                mtu: 65536,
+                qdisc: "noqueue".to_string(),
+                operstate: "UNKNOWN".to_string(),
+                group: "default".to_string(),
+                txqlen: 1000,
+                link_type: "loopback".to_string(),
+                address: Some("00:00:00:00:00:00".to_string()),
+                link_pointtopoint: None,
+                broadcast: Some("00:00:00:00:00:00".to_string()),
+                addr_info: vec![
+                    AddrInfo {
+                        family: "inet".to_string(),
+                        local: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+                        address: None,
+                        prefixlen: 8,
+                        broadcast: None,
+                        scope: "host".to_string(),
+                        dynamic: None,
+                        mngtmpaddr: None,
+                        noprefixroute: None,
+                        label: Some("lo".to_string()),
+                        valid_life_time: 4294967295,
+                        preferred_life_time: 4294967295,
+                    },
+                    AddrInfo {
+                        family: "inet6".to_string(),
+                        local: IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)),
+                        address: None,
+                        prefixlen: 128,
+                        broadcast: None,
+                        scope: "host".to_string(),
+                        dynamic: None,
+                        mngtmpaddr: None,
+                        noprefixroute: None,
+                        label: None,
+                        valid_life_time: 4294967295,
+                        preferred_life_time: 4294967295,
+                    },
+                ],
+            },
+        ]);
+    }
+}

--- a/src/infrastructure/cmd/runner/mod.rs
+++ b/src/infrastructure/cmd/runner/mod.rs
@@ -3,6 +3,7 @@ use tokio::process::Command;
 
 pub mod bgp;
 pub mod ddns;
+pub mod interface;
 pub mod load_balance;
 pub mod pppoe;
 pub mod version;

--- a/src/infrastructure/config/env.rs
+++ b/src/infrastructure/config/env.rs
@@ -3,6 +3,9 @@ use envy::Error;
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deref, Deserialize, From, PartialEq)]
+pub struct IpCommand(String);
+
+#[derive(Clone, Debug, Deref, Deserialize, From, PartialEq)]
 pub struct OpCommand(String);
 
 #[derive(Clone, Debug, Deref, Deserialize, From, PartialEq)]
@@ -17,6 +20,9 @@ pub struct Config {
     pub tls_cert: Option<String>,
     pub tls_key: Option<String>,
 
+    #[serde(default = "default_ip_command")]
+    pub ip_command: IpCommand,
+
     #[serde(default = "default_op_command")]
     pub op_command: OpCommand,
 
@@ -29,6 +35,10 @@ pub struct Config {
 
 pub fn get() -> anyhow::Result<Config, Error> {
     envy::from_env()
+}
+
+fn default_ip_command() -> IpCommand {
+    IpCommand("/bin/ip".to_string())
 }
 
 fn default_op_command() -> OpCommand {

--- a/src/service/interface.rs
+++ b/src/service/interface.rs
@@ -1,0 +1,3 @@
+use crate::domain::interface::Interface;
+
+pub type InterfaceResult = Vec<Interface>;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 
 pub mod bgp;
 pub mod ddns;
+pub mod interface;
 pub mod load_balance;
 pub mod pppoe;
 pub mod version;


### PR DESCRIPTION
Closes #63 

Add a new label called `local_ip_address` that is collected from `ip` command to all the PPPoE client session metrics.