### PR TITLE
Fix DDNS to be properly handled when misconfigured

### DIFF
--- a/src/application/metrics/ddns.rs
+++ b/src/application/metrics/ddns.rs
@@ -21,7 +21,7 @@ impl From<DdnsStatus> for DdnsStatusLabel {
     fn from(s: DdnsStatus) -> Self {
         let interface_name = s.interface;
         let ip_address = s.ip_address.map(|a| a.to_string()).unwrap_or_default();
-        let hostname = s.host_name;
+        let hostname = s.host_name.unwrap_or_default();
         Self {
             interface_name,
             ip_address,

--- a/src/domain/ddns.rs
+++ b/src/domain/ddns.rs
@@ -6,7 +6,7 @@ use chrono::NaiveDateTime;
 pub struct DdnsStatus {
     pub interface: String,
     pub ip_address: Option<IpAddr>,
-    pub host_name: String,
+    pub host_name: Option<String>,
     pub last_update: Option<NaiveDateTime>,
     pub update_status: Option<DdnsUpdateStatus>,
 }

--- a/src/infrastructure/cmd/runner/ddns.rs
+++ b/src/infrastructure/cmd/runner/ddns.rs
@@ -109,14 +109,14 @@ mod tests {
                 DdnsStatus {
                     interface: "eth0".to_string(),
                     ip_address: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
-                    host_name: "1.example.com".to_string(),
+                    host_name: Some("1.example.com".to_string()),
                     last_update: Some(NaiveDate::from_ymd(2006, 1, 2).and_hms(15, 4, 5)),
                     update_status: Some(DdnsUpdateStatus::Good),
                 },
                 DdnsStatus {
                     interface: "eth1".to_string(),
                     ip_address: None,
-                    host_name: "2.example.com".to_string(),
+                    host_name: Some("2.example.com".to_string()),
                     last_update: Some(NaiveDate::from_ymd(2006, 1, 2).and_hms(15, 4, 6)),
                     update_status: None,
                 },
@@ -128,14 +128,14 @@ mod tests {
             DdnsStatus {
                 interface: "eth0".to_string(),
                 ip_address: Some(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))),
-                host_name: "1.example.com".to_string(),
+                host_name: Some("1.example.com".to_string()),
                 last_update: Some(NaiveDate::from_ymd(2006, 1, 2).and_hms(15, 4, 5)),
                 update_status: Some(DdnsUpdateStatus::Good),
             },
             DdnsStatus {
                 interface: "eth1".to_string(),
                 ip_address: None,
-                host_name: "2.example.com".to_string(),
+                host_name: Some("2.example.com".to_string()),
                 last_update: Some(NaiveDate::from_ymd(2006, 1, 2).and_hms(15, 4, 6)),
                 update_status: None,
             },


### PR DESCRIPTION
When ddclient does not update its status, edgerouter-exporter cannot expose metrics due to parse failure.
```
interface    : eth0 
[ Status will be updated within 60 seconds ]

interface    : eth1 
[ Status will be updated within 60 seconds ]

```