### PR TITLE
Add support for IPsec metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,14 +33,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5d78ce20460b82d3fa150275ed9d55e21064fc7951177baacf86a145c4a4b1f"
 
 [[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.15",
+ "syn 1.0.86",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -211,8 +232,8 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -223,9 +244,9 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.15",
  "rustc_version",
- "syn",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -265,6 +286,8 @@ dependencies = [
  "derive_more",
  "env_logger",
  "envy",
+ "futures",
+ "indexmap",
  "indoc",
  "log",
  "mockall",
@@ -273,6 +296,7 @@ dependencies = [
  "number_prefix",
  "pretty_assertions",
  "prometheus-client",
+ "rsvici",
  "serde",
  "serde_json",
  "tokio",
@@ -283,6 +307,22 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "enum_index"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5532bdea562e7be83060c36185eecccba82fe16729d2eaad2891d65417656dd"
+
+[[package]]
+name = "enum_index_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ab22c8085548bf06190113dca556e149ecdbb05ae5b972a2b9899f26b944ee4"
+dependencies = [
+ "quote 0.3.15",
+ "syn 0.11.11",
+]
 
 [[package]]
 name = "env_logger"
@@ -385,42 +425,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.19"
+name = "futures"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.19"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
-name = "futures-sink"
-version = "0.3.19"
+name = "futures-executor"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
-
-[[package]]
-name = "futures-task"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
-
-[[package]]
-name = "futures-util"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
 dependencies = [
  "futures-core",
  "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.15",
+ "syn 1.0.86",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -535,6 +625,7 @@ checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -629,9 +720,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
 
 [[package]]
 name = "log"
@@ -693,14 +784,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.14"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow 0.3.7",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
@@ -760,8 +852,8 @@ checksum = "79ef208208a0dea3f72221e26e904cdc6db2e481d9ade89081ddd494f1dbaa6b"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -848,6 +940,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720d3ea1055e4e4574c0c0b0f8c3fd4f24c4cdaf465948206dea090b57b526ad"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d992b768490d7fe0d8586d9b5745f6c49f557da6d81dc982b1d167ad4edbb21"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote 1.0.15",
+ "syn 1.0.86",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,8 +1012,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744b6f092ba29c3650faf274db506afd39944f48420f6c86b17cfe0ee1cb36bb"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -958,12 +1071,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
- "unicode-xid",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -985,9 +1108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e12d01b9d66ad9eb4529c57666b6263fc1993cb30261d83ead658fdd932652"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -1036,6 +1165,23 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rsvici"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f872868b8bf48719a0a71d464a95df44a8672bf1cba963aabcc1d9a640e527d4"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "enum_index",
+ "enum_index_derive",
+ "futures-util",
+ "serde",
+ "serde_vici",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1115,8 +1261,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -1143,6 +1289,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_vici"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6046ee77641c3db892e2dd17d313481785393e2185f3f4bf7122da57e03cbd"
+dependencies = [
+ "bytes",
+ "itoa 1.0.1",
+ "num_enum",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,9 +1318,9 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "socket2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -1181,13 +1340,24 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
- "quote",
- "unicode-xid",
+ "quote 1.0.15",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -1195,6 +1365,15 @@ name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20518fe4a4c9acf048008599e464deb21beeae3d3578418951a189c235a7a9a8"
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
+]
 
 [[package]]
 name = "termcolor"
@@ -1212,30 +1391,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.15",
+ "syn 1.0.86",
+]
+
+[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.7.14",
+ "mio 0.8.2",
  "num_cpus",
  "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi 0.3.9",
 ]
@@ -1247,8 +1447,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -1263,6 +1463,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1485,15 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1344,8 +1564,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f480b8f81512e825f337ad51e94c1eb5d3bbdf2b363dcd01e2b19a9ffe3f8e"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
 ]
 
 [[package]]
@@ -1362,6 +1582,12 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 
 [[package]]
 name = "unicode-xid"
@@ -1409,6 +1635,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,8 +1660,8 @@ dependencies = [
  "lazy_static",
  "log",
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
  "wasm-bindgen-shared",
 ]
 
@@ -1439,7 +1671,7 @@ version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
- "quote",
+ "quote 1.0.15",
  "wasm-bindgen-macro-support",
 ]
 
@@ -1450,8 +1682,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn",
+ "quote 1.0.15",
+ "syn 1.0.86",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,12 @@ version = "0.9.0"
 [dependencies.envy]
 version = "0.4.2"
 
-[dependencies.notify]
-version = "4.0.17"
+[dependencies.futures]
+version = "0.3.21"
+
+[dependencies.indexmap]
+version = "1.8.0"
+features = ["serde"]
 
 [dependencies.log]
 version = "0.4.16"
@@ -53,11 +57,17 @@ version = "0.4.16"
 [dependencies.nom]
 version = "7.1.1"
 
+[dependencies.notify]
+version = "4.0.17"
+
 [dependencies.number_prefix]
 version = "0.4.0"
 
 [dependencies.prometheus-client]
 version = "0.15.1"
+
+[dependencies.rsvici]
+version = "0.1.1"
 
 [dependencies.serde]
 version = "1.0.136"
@@ -67,7 +77,7 @@ features = ["derive"]
 version = "1.0.79"
 
 [dependencies.tokio]
-version = "1.16.1"
+version = "1.17.0"
 features = ["macros", "net", "process", "rt-multi-thread"]
 
 [dev-dependencies.indoc]

--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@ $ mv edgerouter-exporter /config/scripts
 # Port number (required)
 export PORT=8080
 
+# Log level (optional; one of trace, debug, info, warn, and error)
+export LOG_LEVEL=info
+
 # TLS certificate and private key (optional; if not specified, exporter is served over HTTP)
 export TLS_CERT=/path/to/tls/cert
 export TLS_KEY=/path/to/tls/key
+
+# Path to Unix socket for VICI (optional)
+export VICI_PATH=/run/charon.vici
 
 # Op command (optional)
 export IP_COMMAND=/bin/ip
@@ -135,6 +141,38 @@ edgerouter_dynamic_dns_status{hostname="1.example.com",interface_name="eth0",ip_
 edgerouter_dynamic_dns_status{hostname="2.example.com",interface_name="eth1",ip_address="192.0.2.2"} 0
 ```
 
+### IPsec VPN
+
+Metrics and labels are designed to be compliant with [IPsec Exporter][] but note
+that the results might not fundamentally equal as both implementations vary.
+
+```
+# HELP ipsec_up Result of IPsec metrics scrape.
+# TYPE ipsec_up gauge
+ipsec_up{tunnel="peer-1.example.com-tunnel-1"} 1
+ipsec_up{tunnel="peer-2.example.com-tunnel-1"} 1
+# HELP ipsec_status Status of IPsec tunnel.
+# TYPE ipsec_status gauge
+ipsec_status{tunnel="peer-1.example.com-tunnel-1"} 0
+ipsec_status{tunnel="peer-2.example.com-tunnel-1"} 0
+# HELP ipsec_in_bytes Total receive bytes for IPsec tunnel.
+# TYPE ipsec_in_bytes gauge
+ipsec_in_bytes{tunnel="peer-1.example.com-tunnel-1"} 1000
+ipsec_in_bytes{tunnel="peer-2.example.com-tunnel-1"} 2000
+# HELP ipsec_out_bytes Total transmit bytes for IPsec tunnel.
+# TYPE ipsec_out_bytes gauge
+ipsec_out_bytes{tunnel="peer-1.example.com-tunnel-1"} 3000
+ipsec_out_bytes{tunnel="peer-2.example.com-tunnel-1"} 4000
+# HELP ipsec_in_packets Total receive packets for IPsec tunnel.
+# TYPE ipsec_in_packets gauge
+ipsec_in_packets{tunnel="peer-1.example.com-tunnel-1"} 5000
+ipsec_in_packets{tunnel="peer-2.example.com-tunnel-1"} 6000
+# HELP ipsec_out_packets Total transmit packets for IPsec tunnel.
+# TYPE ipsec_out_packets gauge
+ipsec_out_packets{tunnel="peer-1.example.com-tunnel-1"} 7000
+ipsec_out_packets{tunnel="peer-2.example.com-tunnel-1"} 8000
+```
+
 ### Load Balancers
 
 ```
@@ -193,3 +231,4 @@ edgerouter_pppoe_client_session_transmit_packets_total{interface_name="pppoe0",i
 
 [workflow-link]:    https://github.com/chitoku-k/edgerouter-exporter/actions?query=branch:master
 [workflow-badge]:   https://img.shields.io/github/workflow/status/chitoku-k/edgerouter-exporter/CI%20Workflow/master.svg?style=flat-square
+[IPsec Exporter]:   https://github.com/dennisstritzke/ipsec_exporter

--- a/src/application/metrics/ipsec.rs
+++ b/src/application/metrics/ipsec.rs
@@ -1,0 +1,121 @@
+use prometheus_client::{
+    encoding::text::Encode,
+    metrics::family::Family,
+    registry::Registry,
+};
+
+use crate::{
+    application::metrics::{Collector, Gauge},
+    domain::ipsec::{ChildSAState, SA, SAState},
+    service::ipsec::IPsecResult,
+};
+
+#[derive(Clone, Hash, PartialEq, Eq, Encode)]
+pub struct IPsecTunnelLabel {
+    tunnel: String,
+}
+
+impl From<SA> for IPsecTunnelLabel {
+    fn from(sa: SA) -> Self {
+        let tunnel = sa.child_sas.into_values()
+            .map(|c| c.name)
+            .next()
+            .unwrap_or_default();
+
+        Self {
+            tunnel,
+        }
+    }
+}
+
+impl Collector for IPsecResult {
+    fn collect(self, registry: &mut Registry) {
+        let ipsec_up = Family::<IPsecTunnelLabel, Gauge>::default();
+        registry.register(
+            "ipsec_up",
+            "Result of IPsec metrics scrape",
+            Box::new(ipsec_up.clone()),
+        );
+
+        let ipsec_status = Family::<IPsecTunnelLabel, Gauge>::default();
+        registry.register(
+            "ipsec_status",
+            "Status of IPsec tunnel",
+            Box::new(ipsec_status.clone()),
+        );
+
+        let ipsec_in_bytes = Family::<IPsecTunnelLabel, Gauge>::default();
+        registry.register(
+            "ipsec_in_bytes",
+            "Total receive bytes for IPsec tunnel",
+            Box::new(ipsec_in_bytes.clone()),
+        );
+
+        let ipsec_out_bytes = Family::<IPsecTunnelLabel, Gauge>::default();
+        registry.register(
+            "ipsec_out_bytes",
+            "Total transmit bytes for IPsec tunnel",
+            Box::new(ipsec_out_bytes.clone()),
+        );
+
+        let ipsec_in_packets = Family::<IPsecTunnelLabel, Gauge>::default();
+        registry.register(
+            "ipsec_in_packets",
+            "Total receive packets for IPsec tunnel",
+            Box::new(ipsec_in_packets.clone()),
+        );
+
+        let ipsec_out_packets = Family::<IPsecTunnelLabel, Gauge>::default();
+        registry.register(
+            "ipsec_out_packets",
+            "Total transmit packets for IPsec tunnel",
+            Box::new(ipsec_out_packets.clone()),
+        );
+
+        for sa in self.into_values() {
+            let child_sa = sa.child_sas.values().next();
+            let (
+                in_bytes,
+                out_bytes,
+                in_packets,
+                out_packets,
+            ) = (
+                child_sa.map(|c| c.bytes_in).unwrap_or_default(),
+                child_sa.map(|c| c.bytes_out).unwrap_or_default(),
+                child_sa.map(|c| c.packets_in).unwrap_or_default(),
+                child_sa.map(|c| c.packets_out).unwrap_or_default(),
+            );
+            let status = match (&sa.state, child_sa.map(|c| &c.state)) {
+                (SAState::Unknown, _) | (_, Some(ChildSAState::Unknown) | None) => 3,
+                (SAState::Established, Some(ChildSAState::Installed | ChildSAState::Rekeying | ChildSAState::Rekeyed)) => 0,
+                (SAState::Established, Some(_)) => 1,
+                _ => 2,
+            };
+            let labels = sa.into();
+
+            ipsec_up
+                .get_or_create(&labels)
+                .set(1);
+
+            ipsec_status
+                .get_or_create(&labels)
+                .set(status);
+
+            ipsec_in_bytes
+                .get_or_create(&labels)
+                .set(in_bytes);
+
+            ipsec_out_bytes
+                .get_or_create(&labels)
+                .set(out_bytes);
+
+            ipsec_in_packets
+                .get_or_create(&labels)
+                .set(in_packets);
+
+            ipsec_out_packets
+                .get_or_create(&labels)
+                .set(out_packets);
+        }
+    }
+}

--- a/src/di/container.rs
+++ b/src/di/container.rs
@@ -3,6 +3,7 @@ use log::LevelFilter;
 use crate::{
     application::{metrics::MetricsHandler, server::Engine},
     infrastructure::{
+        client::runner::ipsec::IPsecRunner,
         cmd::{
             parser::{
                 bgp::BGPParser,
@@ -44,6 +45,7 @@ impl Application {
             MetricsHandler::new(
                 BGPRunner::new(&config.vtysh_command, CommandExecutor, BGPParser),
                 DdnsRunner::new(&config.op_ddns_command, CommandExecutor, DdnsParser),
+                IPsecRunner::new(&config.vici_path),
                 LoadBalanceRunner::new(&config.op_command, CommandExecutor, LoadBalanceParser),
                 PPPoERunner::new(&config.op_command, &config.ip_command, CommandExecutor, PPPoEParser, InterfaceParser),
                 VersionRunner::new(&config.op_command, CommandExecutor, VersionParser),

--- a/src/domain/ipsec.rs
+++ b/src/domain/ipsec.rs
@@ -1,0 +1,91 @@
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct SA {
+    pub uniqueid: u32,
+    pub version: String,
+    pub state: SAState,
+    pub local_host: Option<String>,
+    pub local_port: Option<u32>,
+    pub local_id: String,
+    pub remote_host: Option<String>,
+    pub remote_port: u32,
+    pub remote_id: String,
+    pub remote_xauth_id: Option<String>,
+    pub remote_eap_id: Option<String>,
+    pub encr_alg: String,
+    pub encr_keysize: Option<u32>,
+    pub integ_alg: String,
+    pub integ_keysize: Option<u32>,
+    pub prf_alg: String,
+    pub dh_group: Option<String>,
+    pub established: u64,
+    pub rekey_time: Option<u64>,
+    pub reauth_time: u64,
+    pub child_sas: IndexMap<String, ChildSA>,
+}
+
+// See https://github.com/strongswan/strongswan/blob/5.9.5/src/libcharon/sa/ike_sa.h#L287-L365
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum SAState {
+    Created,
+    Connecting,
+    Established,
+    Passive,
+    Rekeying,
+    Rekeyed,
+    Deleting,
+    Destroying,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub struct ChildSA {
+    pub name: String,
+    pub uniqueid: u32,
+    pub reqid: u32,
+    pub state: ChildSAState,
+    pub mode: String,
+    pub protocol: String,
+    pub encr_alg: String,
+    pub encr_keysize: Option<u32>,
+    pub integ_alg: String,
+    pub integ_keysize: Option<u32>,
+    pub prf_alg: Option<String>,
+    pub dh_group: Option<String>,
+    pub esn: Option<u32>,
+    pub bytes_in: u64,
+    pub packets_in: u64,
+    pub use_in: Option<u64>,
+    pub bytes_out: u64,
+    pub packets_out: u64,
+    pub use_out: Option<u64>,
+    pub rekey_time: Option<u64>,
+    pub life_time: u64,
+    pub install_time: u64,
+    pub local_ts: Vec<String>,
+    pub remote_ts: Vec<String>,
+}
+
+// See https://github.com/strongswan/strongswan/blob/5.9.5/src/libcharon/sa/child_sa.h#L37-L96
+#[derive(Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum ChildSAState {
+    Created,
+    Routed,
+    Installing,
+    Installed,
+    Updating,
+    Rekeying,
+    Rekeyed,
+    Retrying,
+    Deleting,
+    Destroying,
+    #[serde(other)]
+    Unknown,
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,6 +1,7 @@
 pub mod bgp;
 pub mod ddns;
 pub mod interface;
+pub mod ipsec;
 pub mod load_balance;
 pub mod pppoe;
 pub mod version;

--- a/src/infrastructure/client/mod.rs
+++ b/src/infrastructure/client/mod.rs
@@ -1,0 +1,1 @@
+pub mod runner;

--- a/src/infrastructure/client/runner/ipsec.rs
+++ b/src/infrastructure/client/runner/ipsec.rs
@@ -1,0 +1,55 @@
+use std::io::ErrorKind;
+
+use async_trait::async_trait;
+use futures::TryStreamExt;
+use indexmap::IndexMap;
+
+use crate::{
+    domain::ipsec::SA,
+    infrastructure::config::env::ViciPath,
+    service::{ipsec::IPsecResult, Runner},
+};
+
+type SAs = IndexMap<String, SA>;
+
+#[derive(Clone)]
+pub struct IPsecRunner {
+    path: ViciPath,
+}
+
+impl IPsecRunner {
+    pub fn new(path: &ViciPath) -> Self {
+        let path = path.to_owned();
+        Self {
+            path,
+        }
+    }
+
+    async fn sas(&self) -> anyhow::Result<IPsecResult> {
+        let mut client = match rsvici::unix::connect(self.path.as_str()).await {
+            Ok(client) => client,
+            Err(e) if e.kind() == ErrorKind::NotFound => {
+                log::debug!("failed to connect to strongSwan: {e}");
+                return Ok(IndexMap::new());
+            },
+            Err(e) => {
+                return Err(e.into());
+            },
+        };
+
+        let stream = client.stream_request("list-sas", "list-sa", ());
+        let items: Vec<SAs> = stream.try_collect().await?;
+        let sas = items.into_iter().flatten().collect();
+
+        Ok(sas)
+    }
+}
+
+#[async_trait]
+impl Runner for IPsecRunner {
+    type Item = IPsecResult;
+
+    async fn run(&self) -> anyhow::Result<Self::Item> {
+        self.sas().await
+    }
+}

--- a/src/infrastructure/client/runner/mod.rs
+++ b/src/infrastructure/client/runner/mod.rs
@@ -1,0 +1,1 @@
+pub mod ipsec;

--- a/src/infrastructure/config/env.rs
+++ b/src/infrastructure/config/env.rs
@@ -3,6 +3,9 @@ use envy::Error;
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deref, Deserialize, From, PartialEq)]
+pub struct ViciPath(String);
+
+#[derive(Clone, Debug, Deref, Deserialize, From, PartialEq)]
 pub struct IpCommand(String);
 
 #[derive(Clone, Debug, Deref, Deserialize, From, PartialEq)]
@@ -20,6 +23,9 @@ pub struct Config {
     pub tls_cert: Option<String>,
     pub tls_key: Option<String>,
 
+    #[serde(default = "default_vici_path")]
+    pub vici_path: ViciPath,
+
     #[serde(default = "default_ip_command")]
     pub ip_command: IpCommand,
 
@@ -35,6 +41,10 @@ pub struct Config {
 
 pub fn get() -> anyhow::Result<Config, Error> {
     envy::from_env()
+}
+
+fn default_vici_path() -> ViciPath {
+    ViciPath("/run/charon.vici".to_string())
 }
 
 fn default_ip_command() -> IpCommand {

--- a/src/infrastructure/mod.rs
+++ b/src/infrastructure/mod.rs
@@ -1,2 +1,3 @@
+pub mod client;
 pub mod cmd;
 pub mod config;

--- a/src/service/ipsec.rs
+++ b/src/service/ipsec.rs
@@ -1,0 +1,5 @@
+use indexmap::IndexMap;
+
+use crate::domain::ipsec::SA;
+
+pub type IPsecResult = IndexMap<String, SA>;

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 pub mod bgp;
 pub mod ddns;
 pub mod interface;
+pub mod ipsec;
 pub mod load_balance;
 pub mod pppoe;
 pub mod version;


### PR DESCRIPTION
Metrics and labels are designed to be compliant with [dennisstritzke/ipsec_exporter](https://github.com/dennisstritzke/ipsec_exporter) but edgerouter-exporter uses the VICI protocol to communicate with the charon daemon.