### PR TITLE
Fix IPsec metrics caused metrics scrape to fail

### DIFF
--- a/src/domain/ipsec.rs
+++ b/src/domain/ipsec.rs
@@ -51,7 +51,7 @@ pub struct ChildSA {
     pub reqid: u32,
     pub state: ChildSAState,
     pub mode: String,
-    pub protocol: String,
+    pub protocol: Option<String>,
     pub encr_alg: String,
     pub encr_keysize: Option<u32>,
     pub integ_alg: String,


### PR DESCRIPTION
When any of Child SAs is closed, ipsec metrics causes an error in deserializing IPsec metrics:
```
[2022-04-12T05:42:48Z ERROR] failed to collect metrics: missing field `protocol`
```