### PR TITLE
Improve error messages

### DIFF
--- a/src/application/metrics/mod.rs
+++ b/src/application/metrics/mod.rs
@@ -95,7 +95,7 @@ where
             (StatusCode::OK, s)
         },
         Err(e) => {
-            log::error!("failed to collect metrics: {e}");
+            log::error!("failed to collect metrics\nError: {e:?}");
             (StatusCode::INTERNAL_SERVER_ERROR, String::new())
         },
     }

--- a/src/di/container.rs
+++ b/src/di/container.rs
@@ -33,6 +33,7 @@ impl Application {
         env_logger::builder()
             .format_target(false)
             .format_timestamp_secs()
+            .format_indent(None)
             .filter(None, LevelFilter::Info)
             .parse_env("LOG_LEVEL")
             .init();

--- a/src/infrastructure/client/runner/ipsec.rs
+++ b/src/infrastructure/client/runner/ipsec.rs
@@ -1,6 +1,6 @@
 use std::io::ErrorKind;
 
-use anyhow::{anyhow, Context};
+use anyhow::{Context, Error};
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use indexmap::IndexMap;
@@ -33,7 +33,7 @@ impl IPsecRunner {
                 return Ok(IndexMap::new());
             },
             Err(e) => {
-                return Err(anyhow!(e).context("error connecting to strongSwan"));
+                return Err(Error::from(e).context("error connecting to strongSwan"));
             },
         };
 

--- a/src/infrastructure/client/runner/ipsec.rs
+++ b/src/infrastructure/client/runner/ipsec.rs
@@ -1,5 +1,6 @@
 use std::io::ErrorKind;
 
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use indexmap::IndexMap;
@@ -28,16 +29,16 @@ impl IPsecRunner {
         let mut client = match rsvici::unix::connect(self.path.as_str()).await {
             Ok(client) => client,
             Err(e) if e.kind() == ErrorKind::NotFound => {
-                log::debug!("failed to connect to strongSwan: {e}");
+                log::debug!("failed to connect to strongSwan at {}: {e}", self.path.as_str());
                 return Ok(IndexMap::new());
             },
             Err(e) => {
-                return Err(e.into());
+                return Err(anyhow!(e).context("error connecting to strongSwan"));
             },
         };
 
         let stream = client.stream_request("list-sas", "list-sa", ());
-        let items: Vec<SAs> = stream.try_collect().await?;
+        let items: Vec<SAs> = stream.try_collect().await.context("error retrieving IPsec SAs")?;
         let sas = items.into_iter().flatten().collect();
 
         Ok(sas)

--- a/src/infrastructure/cmd/parser/interface.rs
+++ b/src/infrastructure/cmd/parser/interface.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+
 use crate::{
     domain::interface::Interface,
     infrastructure::cmd::parser::Parser,
@@ -17,7 +19,7 @@ impl Parser for InterfaceParser {
 }
 
 fn parse_interface(input: &str) -> anyhow::Result<Vec<Interface>> {
-    let interfaces = serde_json::from_str(input)?;
+    let interfaces = serde_json::from_str(input).context("error parsing interfaces")?;
     Ok(interfaces)
 }
 

--- a/src/infrastructure/cmd/parser/mod.rs
+++ b/src/infrastructure/cmd/parser/mod.rs
@@ -1,12 +1,14 @@
-use std::time::Duration;
+use std::{time, str::FromStr};
 
+use derive_more::Into;
 use nom::{
     branch::alt,
     bytes::complete::tag,
     character::complete::u64,
     combinator::map,
+    error::Error,
     sequence::{terminated, tuple},
-    IResult,
+    Finish, IResult,
 };
 
 pub mod bgp;
@@ -23,7 +25,19 @@ pub trait Parser {
     fn parse(&self, input: Self::Input) -> anyhow::Result<Self::Item>;
 }
 
-pub fn parse_duration(input: &str) -> IResult<&str, Duration> {
+#[derive(Into)]
+pub struct Duration(time::Duration);
+
+impl FromStr for Duration {
+    type Err = Error<String>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (_, duration) = parse_duration(s).map_err(|e| e.to_owned()).finish()?;
+        Ok(Duration(duration))
+    }
+}
+
+fn parse_duration(input: &str) -> IResult<&str, time::Duration> {
     alt((
         map(
             tuple((
@@ -31,7 +45,7 @@ pub fn parse_duration(input: &str) -> IResult<&str, Duration> {
                 terminated(u64, tag(":")),
                 u64,
             )),
-            |(h, m, s)| Duration::new(h * 60 * 60 + m * 60 + s, 0),
+            |(h, m, s)| time::Duration::new(h * 60 * 60 + m * 60 + s, 0),
         ),
         map(
             tuple((
@@ -39,7 +53,7 @@ pub fn parse_duration(input: &str) -> IResult<&str, Duration> {
                 terminated(u64, tag("m")),
                 terminated(u64, tag("s")),
             )),
-            |(h, m, s)| Duration::new(h * 60 * 60 + m * 60 + s, 0),
+            |(h, m, s)| time::Duration::new(h * 60 * 60 + m * 60 + s, 0),
         ),
         map(
             tuple((
@@ -47,7 +61,7 @@ pub fn parse_duration(input: &str) -> IResult<&str, Duration> {
                 terminated(u64, tag("d")),
                 terminated(u64, tag("h")),
             )),
-            |(w, d, h)| Duration::new(w * 7 * 24 * 60 * 60 + d * 24 * 60 * 60 + h * 60 * 60, 0),
+            |(w, d, h)| time::Duration::new(w * 7 * 24 * 60 * 60 + d * 24 * 60 * 60 + h * 60 * 60, 0),
         ),
         map(
             tuple((
@@ -55,7 +69,7 @@ pub fn parse_duration(input: &str) -> IResult<&str, Duration> {
                 terminated(u64, tag("h")),
                 terminated(u64, tag("m")),
             )),
-            |(d, h, m)| Duration::new(d * 24 * 60 * 60 + h * 60 * 60 + m * 60, 0),
+            |(d, h, m)| time::Duration::new(d * 24 * 60 * 60 + h * 60 * 60 + m * 60, 0),
         ),
     ))(input)
 }

--- a/src/infrastructure/cmd/runner/mod.rs
+++ b/src/infrastructure/cmd/runner/mod.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use async_trait::async_trait;
 use tokio::process::Command;
 
@@ -13,7 +14,7 @@ pub trait Executor {
     async fn output<'a>(&self, command: &str, args: &[&'a str]) -> anyhow::Result<String> {
         log::debug!("executing {command} with {args:?}");
 
-        let output = Command::new(command).args(args).output().await?;
+        let output = Command::new(command).args(args).output().await.context(format!("error executing {command} with {args:?}"))?;
         let result = String::from_utf8(output.stdout)?;
         Ok(result)
     }

--- a/src/infrastructure/config/env.rs
+++ b/src/infrastructure/config/env.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Context};
 use derive_more::{Deref, From};
 use envy::Error;
 use serde::Deserialize;
@@ -39,8 +40,13 @@ pub struct Config {
     pub vtysh_command: VtyshCommand,
 }
 
-pub fn get() -> anyhow::Result<Config, Error> {
+pub fn get() -> anyhow::Result<Config> {
     envy::from_env()
+        .map_err(|e| match e {
+            Error::MissingValue(field) => anyhow!("missing value for {}", field.to_ascii_uppercase()),
+            Error::Custom(e) => anyhow!(e),
+        })
+        .context("error reading environment variables")
 }
 
 fn default_vici_path() -> ViciPath {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use edgerouter_exporter::di::container::Application;
 #[tokio::main]
 async fn main() {
     if let Err(e) = Application::start().await {
-        log::error!("failed to start application: {e}");
+        log::error!("failed to start application\nError: {e:?}");
         exit(1);
     }
 }


### PR DESCRIPTION
Error messages are now pretty printed with its root cause:
```
[2022-04-14T17:16:04Z ERROR] failed to start application
Error: error reading environment variables

Caused by:
    missing value for PORT
```

```
[2022-04-14T17:16:18Z ERROR] failed to start application
Error: error starting server

Caused by:
    Permission denied (os error 13)
```

```
[2022-04-14T17:18:10Z ERROR] failed to start application
Error: error loading TLS certificates

Caused by:
    private key not found
```

```
[2022-04-14T17:17:21Z ERROR] failed to collect metrics
Error: error executing /opt/vyatta/sbin/ubnt_vtysh with ["-c", "show ip bgp summary"]

Caused by:
    No such file or directory (os error 2)
```