### PR TITLE
Fix missing prf_alg field caused scrape to fail

### DIFF
--- a/src/domain/ipsec.rs
+++ b/src/domain/ipsec.rs
@@ -19,7 +19,7 @@ pub struct SA {
     pub encr_keysize: Option<u32>,
     pub integ_alg: Option<String>,
     pub integ_keysize: Option<u32>,
-    pub prf_alg: String,
+    pub prf_alg: Option<String>,
     pub dh_group: Option<String>,
     pub established: u64,
     pub rekey_time: Option<u64>,


### PR DESCRIPTION
```
[2022-04-17T05:01:24Z ERROR] failed to collect metrics
Error: error retrieving IPsec SAs

Caused by:
    0: missing field `prf-alg`
    1: missing field `prf-alg`
```