### PR TITLE
Validate status code from processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "env_logger",
  "envy",
  "futures",
+ "indenter",
  "indexmap",
  "indoc",
  "log",
@@ -633,6 +634,12 @@ dependencies = [
  "wasm-bindgen",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ version = "0.4.2"
 [dependencies.futures]
 version = "0.3.23"
 
+[dependencies.indenter]
+version = "0.3.3"
+
 [dependencies.indexmap]
 version = "1.9.1"
 features = ["serde"]


### PR DESCRIPTION
This PR strengthens and enriches error reporting by:
* validating status code from processes
* including stdout/stderr from output when the command fails

```
[2022-08-25T16:03:42Z ERROR] failed to collect metrics
Error: error executing /bin/ip with ["--invalid-option", "addr", "show"]
Stdout:
Stderr:
    Option "-invalid-option" is unknown, try "ip -help".

Caused by:
    Process exited with 255
```