### PR TITLE
Derive ViciPath with derive_more::AsRef

### DIFF
--- a/src/infrastructure/client/runner/ipsec.rs
+++ b/src/infrastructure/client/runner/ipsec.rs
@@ -26,10 +26,10 @@ impl IPsecRunner {
     }
 
     async fn sas(&self) -> anyhow::Result<IPsecResult> {
-        let mut client = match rsvici::unix::connect(self.path.as_str()).await {
+        let mut client = match rsvici::unix::connect(&self.path).await {
             Ok(client) => client,
             Err(e) if e.kind() == ErrorKind::NotFound => {
-                log::debug!("failed to connect to strongSwan at {}: {e}", self.path.as_str());
+                log::debug!("failed to connect to strongSwan at {:?}: {e}", &self.path);
                 return Ok(IndexMap::new());
             },
             Err(e) => {

--- a/src/infrastructure/config/env.rs
+++ b/src/infrastructure/config/env.rs
@@ -1,9 +1,10 @@
 use anyhow::{anyhow, Context};
-use derive_more::{Deref, From};
+use derive_more::{AsRef, Deref, From};
 use envy::Error;
 use serde::Deserialize;
 
-#[derive(Clone, Debug, Deref, Deserialize, Eq, From, PartialEq)]
+#[derive(AsRef, Clone, Debug, Deref, Deserialize, Eq, From, PartialEq)]
+#[as_ref(forward)]
 pub struct ViciPath(String);
 
 #[derive(Clone, Debug, Deref, Deserialize, Eq, From, PartialEq)]


### PR DESCRIPTION
Refactors `crate::infrastructure::config::env::ViciPath` using `dervie_more::AsRef`.