### PR TITLE
Switch to clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69d64e88428747154bd8bc378d178377ef4dace7a5735ca1f3855be72f2c2cb5"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote 1.0.15",
+ "syn 1.0.96",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,9 +287,9 @@ dependencies = [
  "atomic-shim",
  "axum",
  "chrono",
+ "clap",
  "derive_more",
  "env_logger",
- "envy",
  "futures",
  "hyper",
  "indenter",
@@ -307,15 +342,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "envy"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -479,6 +505,12 @@ name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -887,6 +919,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1015,10 +1053,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.39"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote 1.0.15",
+ "syn 1.0.96",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.15",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1203,6 +1265,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1481,6 +1549,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,16 @@ default-features = false
 [dependencies.chrono]
 version = "0.4.22"
 
+[dependencies.clap]
+version = "4.0.12"
+features = ["cargo", "derive", "env", "help", "std", "string", "suggestions", "usage"]
+default-features = false
+
 [dependencies.derive_more]
 version = "0.99.0"
 
 [dependencies.env_logger]
 version = "0.9.1"
-
-[dependencies.envy]
-version = "0.4.2"
 
 [dependencies.futures]
 version = "0.3.24"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ $ mv edgerouter-exporter /config/scripts
 
 ### Configuration
 
+Configure by either of the following options.
+
+#### Command-line options
+
+See `edgerouter-exporter --help`.
+
+#### Environment variables
+
 ```sh
 # Port number (required)
 export PORT=8080

--- a/src/di/container.rs
+++ b/src/di/container.rs
@@ -38,7 +38,7 @@ impl Application {
             .parse_env("LOG_LEVEL")
             .init();
 
-        let config = env::get()?;
+        let config = env::get();
         let engine = Engine::new(
             config.port,
             config.tls_cert,


### PR DESCRIPTION
This PR allows configuration through command-line options as well as additional features like `--help` and `--version`. Currently, `--log-level` is not implemented as configuration is done after logger is initialized.

```
admin@ubnt:~$ ./edgerouter-exporter --help
Usage: edgerouter-exporter [OPTIONS] --port <PORT>

Options:
      --port <PORT>
          Port number [env: PORT=]
      --tls-cert <TLS_CERT>
          Path to TLS certificate (if not specified, exporter is served over HTTP) [env: TLS_CERT=]
      --tls-key <TLS_KEY>
          Path to TLS private key (if not specified, exporter is served over HTTP) [env: TLS_KEY=]
      --vici-path <VICI_PATH>
          Path to Unix socket for VICI [env: VICI_PATH=] [default: /run/charon.vici]
      --ip-command <IP_COMMAND>
          Path to ip command [env: IP_COMMAND=] [default: /bin/ip]
      --op-command <OP_COMMAND>
          Path to op command [env: OP_COMMAND=] [default: /opt/vyatta/bin/vyatta-op-cmd-wrapper]
      --op-ddns-command <OP_DDNS_COMMAND>
          Path to op ddns command [env: OP_DDNS_COMMAND=] [default: /opt/vyatta/bin/sudo-users/vyatta-op-dynamic-dns.pl]
      --vtysh-command <VTYSH_COMMAND>
          Path to vtysh command [env: VTYSH_COMMAND=] [default: /opt/vyatta/sbin/ubnt_vtysh]
  -h, --help
          Print help information
  -V, --version
          Print version information
```

```
admin@ubnt:~$ ./edgerouter-exporter --version
edgerouter-exporter 2.7.0 (OpenSSL 1.1.0l  10 Sep 2019)
```