### PR TITLE
Wrap State with Arc<T>

### DIFF
--- a/src/application/metrics/mod.rs
+++ b/src/application/metrics/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use axum::{extract::State, http::StatusCode, response::IntoResponse};
 use derive_more::Constructor;
@@ -84,7 +86,7 @@ where
     }
 }
 
-pub async fn handle<T>(State(controller): State<T>) -> impl IntoResponse
+pub async fn handle<T>(State(controller): State<Arc<T>>) -> impl IntoResponse
 where
     T: Controller<String>,
 {

--- a/src/application/metrics/mod.rs
+++ b/src/application/metrics/mod.rs
@@ -33,7 +33,7 @@ pub trait Collector {
     fn collect(self, registry: &mut Registry);
 }
 
-#[derive(Clone, Constructor)]
+#[derive(Constructor)]
 pub struct MetricsHandler<BGPRunner, DdnsRunner, IPsecRunner, LoadBalanceRunner, PPPoERunner, VersionRunner> {
     bgp_runner: BGPRunner,
     ddns_runner: DdnsRunner,

--- a/src/application/metrics/mod.rs
+++ b/src/application/metrics/mod.rs
@@ -47,12 +47,12 @@ pub struct MetricsHandler<BGPRunner, DdnsRunner, IPsecRunner, LoadBalanceRunner,
 impl<BGPRunner, DdnsRunner, IPsecRunner, LoadBalanceRunner, PPPoERunner, VersionRunner> Controller<String>
     for MetricsHandler<BGPRunner, DdnsRunner, IPsecRunner, LoadBalanceRunner, PPPoERunner, VersionRunner>
 where
-    BGPRunner: Runner<Item = (BGPStatusResult, BGPStatusResult)> + Send + Sync + Clone + 'static,
-    DdnsRunner: Runner<Item = DdnsStatusResult> + Send + Sync + Clone + 'static,
-    IPsecRunner: Runner<Item = IPsecResult> + Send + Sync + Clone + 'static,
-    LoadBalanceRunner: Runner<Item = LoadBalanceStatusResult> + Send + Sync + Clone + 'static,
-    PPPoERunner: Runner<Item = PPPoEClientSessionResult> + Send + Sync + Clone + 'static,
-    VersionRunner: Runner<Item = VersionResult> + Send + Sync + Clone + 'static,
+    BGPRunner: Runner<Item = (BGPStatusResult, BGPStatusResult)> + Send + Sync + 'static,
+    DdnsRunner: Runner<Item = DdnsStatusResult> + Send + Sync + 'static,
+    IPsecRunner: Runner<Item = IPsecResult> + Send + Sync + 'static,
+    LoadBalanceRunner: Runner<Item = LoadBalanceStatusResult> + Send + Sync + 'static,
+    PPPoERunner: Runner<Item = PPPoEClientSessionResult> + Send + Sync + 'static,
+    VersionRunner: Runner<Item = VersionResult> + Send + Sync + 'static,
 {
     async fn handle(&self) -> anyhow::Result<String> {
         let mut registry = Registry::default();

--- a/src/application/server.rs
+++ b/src/application/server.rs
@@ -24,7 +24,6 @@ pub trait Controller<T> {
     async fn handle(&self) -> anyhow::Result<T>;
 }
 
-#[derive(Clone)]
 pub struct Engine<MetricsController> {
     port: u16,
     tls: Option<(String, String)>,
@@ -33,7 +32,7 @@ pub struct Engine<MetricsController> {
 
 impl<MetricsController> Engine<MetricsController>
 where
-    MetricsController: Controller<String> + Send + Sync + Clone + 'static,
+    MetricsController: Controller<String> + Send + Sync + 'static,
 {
     pub fn new(
         port: u16,

--- a/src/application/server.rs
+++ b/src/application/server.rs
@@ -1,4 +1,4 @@
-use std::net::Ipv6Addr;
+use std::{net::Ipv6Addr, sync::Arc};
 
 use anyhow::Context;
 use async_trait::async_trait;
@@ -55,7 +55,7 @@ where
 
         let metrics = Router::new()
             .route("/", get(metrics::handle::<MetricsController>))
-            .with_state(self.metrics_controller);
+            .with_state(Arc::new(self.metrics_controller));
 
         let addr = (Ipv6Addr::UNSPECIFIED, self.port).into();
         let app = Router::new()

--- a/src/infrastructure/client/runner/ipsec.rs
+++ b/src/infrastructure/client/runner/ipsec.rs
@@ -13,7 +13,6 @@ use crate::{
 
 type SAs = IndexMap<String, SA>;
 
-#[derive(Clone)]
 pub struct IPsecRunner {
     path: ViciPath,
 }

--- a/src/infrastructure/cmd/parser/bgp.rs
+++ b/src/infrastructure/cmd/parser/bgp.rs
@@ -18,7 +18,6 @@ use crate::{
     service::bgp::BGPStatusResult,
 };
 
-#[derive(Clone)]
 pub struct BGPParser;
 
 impl Parser for BGPParser {

--- a/src/infrastructure/cmd/parser/ddns.rs
+++ b/src/infrastructure/cmd/parser/ddns.rs
@@ -17,7 +17,6 @@ use crate::{
     service::ddns::DdnsStatusResult,
 };
 
-#[derive(Clone)]
 pub struct DdnsParser;
 
 impl Parser for DdnsParser {

--- a/src/infrastructure/cmd/parser/interface.rs
+++ b/src/infrastructure/cmd/parser/interface.rs
@@ -18,7 +18,6 @@ use crate::{
     service::interface::InterfaceResult,
 };
 
-#[derive(Clone)]
 pub struct InterfaceParser;
 
 impl Parser for InterfaceParser {

--- a/src/infrastructure/cmd/parser/load_balance.rs
+++ b/src/infrastructure/cmd/parser/load_balance.rs
@@ -28,10 +28,8 @@ use crate::{
     service::load_balance::{LoadBalanceStatusResult, LoadBalanceWatchdogResult},
 };
 
-#[derive(Clone)]
 pub struct LoadBalanceStatusParser;
 
-#[derive(Clone)]
 pub struct LoadBalanceWatchdogParser;
 
 impl Parser for LoadBalanceStatusParser {

--- a/src/infrastructure/cmd/parser/pppoe.rs
+++ b/src/infrastructure/cmd/parser/pppoe.rs
@@ -21,7 +21,6 @@ use crate::{
     service::pppoe::PPPoEClientSessionResult,
 };
 
-#[derive(Clone)]
 pub struct PPPoEParser;
 
 impl Parser for PPPoEParser {

--- a/src/infrastructure/cmd/parser/version.rs
+++ b/src/infrastructure/cmd/parser/version.rs
@@ -16,7 +16,6 @@ use crate::{
     service::version::VersionResult,
 };
 
-#[derive(Clone)]
 pub struct VersionParser;
 
 impl Parser for VersionParser {

--- a/src/infrastructure/cmd/runner/bgp.rs
+++ b/src/infrastructure/cmd/runner/bgp.rs
@@ -9,7 +9,6 @@ use crate::{
     service::{bgp::BGPStatusResult, Runner},
 };
 
-#[derive(Clone)]
 pub struct BGPRunner<E, P> {
     command: VtyshCommand,
     executor: E,

--- a/src/infrastructure/cmd/runner/ddns.rs
+++ b/src/infrastructure/cmd/runner/ddns.rs
@@ -8,7 +8,6 @@ use crate::{
     service::{ddns::DdnsStatusResult, Runner},
 };
 
-#[derive(Clone)]
 pub struct DdnsRunner<E, P> {
     command: OpDdnsCommand,
     executor: E,

--- a/src/infrastructure/cmd/runner/load_balance.rs
+++ b/src/infrastructure/cmd/runner/load_balance.rs
@@ -11,7 +11,6 @@ use crate::{
     },
 };
 
-#[derive(Clone)]
 pub struct LoadBalanceRunner<E, StatusParser, WatchdogParser> {
     command: OpCommand,
     executor: E,

--- a/src/infrastructure/cmd/runner/mod.rs
+++ b/src/infrastructure/cmd/runner/mod.rs
@@ -48,7 +48,6 @@ impl fmt::Debug for Output<'_> {
     }
 }
 
-#[derive(Clone)]
 pub struct CommandExecutor;
 
 impl Executor for CommandExecutor {}

--- a/src/infrastructure/cmd/runner/pppoe.rs
+++ b/src/infrastructure/cmd/runner/pppoe.rs
@@ -13,7 +13,6 @@ use crate::{
     },
 };
 
-#[derive(Clone)]
 pub struct PPPoERunner<E, PPPoEParser, InterfaceParser> {
     op_command: OpCommand,
     ip_command: IpCommand,

--- a/src/infrastructure/cmd/runner/version.rs
+++ b/src/infrastructure/cmd/runner/version.rs
@@ -8,7 +8,6 @@ use crate::{
     service::{version::VersionResult, Runner},
 };
 
-#[derive(Clone)]
 pub struct VersionRunner<E, P> {
     command: OpCommand,
     executor: E,


### PR DESCRIPTION
The `Controller` instance has not been wrapped with `std::sync::Arc<T>` since #200 which wasn't intended. The change in #200 has caused `Clone::clone()` to be called which are unnecessary.