### PR TITLE
Use latest version for ghcr.io/cross-rs/mips{,el}-unknown-linux-gnu

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -13,14 +13,14 @@ pre-build = [
 ]
 
 [target.mipsel-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/mipsel-unknown-linux-gnu:0.2.5"
+image = "ghcr.io/cross-rs/mipsel-unknown-linux-gnu"
 env.passthrough = [
     "RUSTFLAGS=-C strip=symbols",
     "OPENSSL_DIR=/usr/mipsel-linux-gnu",
 ]
 
 [target.mips-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/mips-unknown-linux-gnu:0.2.5"
+image = "ghcr.io/cross-rs/mips-unknown-linux-gnu"
 env.passthrough = [
     "RUSTFLAGS=-C strip=symbols",
     "OPENSSL_DIR=/usr/mips-linux-gnu",


### PR DESCRIPTION
The latest tag is currently based on Ubuntu Xenial which comes with glibc 2.23 so it is still compatible with EdgeOS 2.0.9 that is shipped with glibc 2.24-11+deb9u4.

* Ubuntu Xenial Xerus: https://launchpad.net/ubuntu/xenial/+source/glibc
  * glibc 2.23-0ubuntu11.3
* Debian "stretch": https://launchpad.net/debian/stretch/+source/glibc
  * glibc 2.24-11+deb9u4