### PR TITLE
Reduce explicit lifetime parameters of `Parser`

### DIFF
--- a/src/infrastructure/cmd/parser.rs
+++ b/src/infrastructure/cmd/parser.rs
@@ -19,10 +19,10 @@ pub mod pppoe;
 pub mod version;
 
 pub trait Parser {
-    type Input<'a>;
+    type Context<'a>;
     type Item;
 
-    fn parse(&self, input: Self::Input<'_>) -> anyhow::Result<Self::Item>;
+    fn parse(&self, input: &str, context: Self::Context<'_>) -> anyhow::Result<Self::Item>;
 }
 
 #[derive(Into)]

--- a/src/infrastructure/cmd/parser/bgp.rs
+++ b/src/infrastructure/cmd/parser/bgp.rs
@@ -23,10 +23,10 @@ const BGP_VERSION: &str = "4";
 pub struct BGPParser;
 
 impl Parser for BGPParser {
-    type Input<'a> = &'a str;
+    type Context<'a> = ();
     type Item = BGPStatusResult;
 
-    fn parse(&self, input: Self::Input<'_>) -> anyhow::Result<Self::Item> {
+    fn parse(&self, input: &str, _context: ()) -> anyhow::Result<Self::Item> {
         parse_bgp_status(input)
             .finish()
             .map(|(_, status)| status)
@@ -189,7 +189,7 @@ mod tests {
         let parser = BGPParser;
         let input = "command not found";
 
-        let actual = parser.parse(input);
+        let actual = parser.parse(input, ());
         assert!(actual.is_err());
     }
 
@@ -198,7 +198,7 @@ mod tests {
         let parser = BGPParser;
         let input = "";
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, None);
     }
 
@@ -224,7 +224,7 @@ mod tests {
             Total number of Established sessions 4
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, Some(BGPStatus {
             router_id: "192.0.2.1".to_string(),
             local_as: 64496,
@@ -341,7 +341,7 @@ mod tests {
             Total number of Established sessions 4
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, Some(BGPStatus {
             router_id: "192.0.2.1".to_string(),
             local_as: 64496,

--- a/src/infrastructure/cmd/parser/ddns.rs
+++ b/src/infrastructure/cmd/parser/ddns.rs
@@ -20,10 +20,10 @@ use crate::{
 pub struct DdnsParser;
 
 impl Parser for DdnsParser {
-    type Input<'a> = &'a str;
+    type Context<'a> = ();
     type Item = DdnsStatusResult;
 
-    fn parse(&self, input: Self::Input<'_>) -> anyhow::Result<Self::Item> {
+    fn parse(&self, input: &str, _context: ()) -> anyhow::Result<Self::Item> {
         parse_ddns_status(input)
             .finish()
             .map(|(_, status)| status)
@@ -146,7 +146,7 @@ mod tests {
         let parser = DdnsParser;
         let input = "";
 
-        assert!(parser.parse(input).is_err());
+        assert!(parser.parse(input, ()).is_err());
     }
 
     #[test]
@@ -157,7 +157,7 @@ mod tests {
 
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![]);
     }
 
@@ -173,7 +173,7 @@ mod tests {
 
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![
             DdnsStatus {
                 interface: "eth0".to_string(),
@@ -209,7 +209,7 @@ mod tests {
 
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![
             DdnsStatus {
                 interface: "eth0".to_string(),

--- a/src/infrastructure/cmd/parser/interface.rs
+++ b/src/infrastructure/cmd/parser/interface.rs
@@ -21,10 +21,10 @@ use crate::{
 pub struct InterfaceParser;
 
 impl Parser for InterfaceParser {
-    type Input<'a> = &'a str;
+    type Context<'a> = ();
     type Item = InterfaceResult;
 
-    fn parse(&self, input: Self::Input<'_>) -> anyhow::Result<Self::Item> {
+    fn parse(&self, input: &str, _context: ()) -> anyhow::Result<Self::Item> {
         parse_interfaces(input)
             .finish()
             .map(|(_, interfaces)| interfaces)
@@ -140,7 +140,7 @@ mod tests {
             pppoe0           UP             203.0.113.1 peer 192.0.2.255/32 
         "#};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![
             Interface {
                 ifname: "lo".to_string(),

--- a/src/infrastructure/cmd/parser/load_balance.rs
+++ b/src/infrastructure/cmd/parser/load_balance.rs
@@ -33,10 +33,10 @@ pub struct LoadBalanceStatusParser;
 pub struct LoadBalanceWatchdogParser;
 
 impl Parser for LoadBalanceStatusParser {
-    type Input<'a> = &'a str;
+    type Context<'a> = ();
     type Item = LoadBalanceStatusResult;
 
-    fn parse(&self, input: Self::Input<'_>) -> anyhow::Result<Self::Item> {
+    fn parse(&self, input: &str, _context: ()) -> anyhow::Result<Self::Item> {
         parse_load_balance_status(input)
             .finish()
             .map(|(_, status)| status)
@@ -46,10 +46,10 @@ impl Parser for LoadBalanceStatusParser {
 }
 
 impl Parser for LoadBalanceWatchdogParser {
-    type Input<'a> = &'a str;
+    type Context<'a> = ();
     type Item = LoadBalanceWatchdogResult;
 
-    fn parse(&self, input: Self::Input<'_>) -> anyhow::Result<Self::Item> {
+    fn parse(&self, input: &str, _context: ()) -> anyhow::Result<Self::Item> {
         parse_load_balance_watchdog(input)
             .finish()
             .map(|(_, groups)| groups)
@@ -388,13 +388,13 @@ mod tests {
         let parser = LoadBalanceStatusParser;
         let input = "";
 
-        let actual = parser.parse(input);
+        let actual = parser.parse(input, ());
         assert!(actual.is_err());
 
         let parser = LoadBalanceWatchdogParser;
         let input = "";
 
-        let actual = parser.parse(input);
+        let actual = parser.parse(input, ());
         assert!(actual.is_err());
     }
 
@@ -403,13 +403,13 @@ mod tests {
         let parser = LoadBalanceStatusParser;
         let input = "load-balance is not configured";
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![]);
 
         let parser = LoadBalanceWatchdogParser;
         let input = "load-balance is not configured";
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![]);
     }
 
@@ -425,7 +425,7 @@ mod tests {
 
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![
             LoadBalanceStatus {
                 name: "FAILOVER_01".to_string(),
@@ -440,7 +440,7 @@ mod tests {
         let parser = LoadBalanceWatchdogParser;
         let input = "Group FAILOVER_01";
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![
             LoadBalanceWatchdog {
                 name: "FAILOVER_01".to_string(),
@@ -489,7 +489,7 @@ mod tests {
 
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![
             LoadBalanceStatus {
                 name: "FAILOVER_01".to_string(),
@@ -564,7 +564,7 @@ mod tests {
 
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![
             LoadBalanceWatchdog {
                 name: "FAILOVER_01".to_string(),
@@ -686,7 +686,7 @@ mod tests {
 
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![
             LoadBalanceStatus {
                 name: "FAILOVER_01".to_string(),
@@ -845,7 +845,7 @@ mod tests {
 
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, vec![
             LoadBalanceWatchdog {
                 name: "FAILOVER_01".to_string(),

--- a/src/infrastructure/cmd/parser/pppoe.rs
+++ b/src/infrastructure/cmd/parser/pppoe.rs
@@ -24,10 +24,10 @@ use crate::{
 pub struct PPPoEParser;
 
 impl Parser for PPPoEParser {
-    type Input<'a> = (&'a str, &'a [Interface]);
+    type Context<'a> = (&'a [Interface],);
     type Item = PPPoEClientSessionResult;
 
-    fn parse(&self, (input, interfaces): Self::Input<'_>) -> anyhow::Result<Self::Item> {
+    fn parse(&self, input: &str, (interfaces,): Self::Context<'_>) -> anyhow::Result<Self::Item> {
         parse_pppoe_client_sessions(input, interfaces)
             .finish()
             .map(|(_, sessions)| sessions)
@@ -191,7 +191,7 @@ mod tests {
         let input = "";
         let interfaces = &[];
 
-        assert!(parser.parse((input, interfaces)).is_err());
+        assert!(parser.parse(input, (interfaces,)).is_err());
     }
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
         let input = "No active PPPoE client sessions";
         let interfaces = &[];
 
-        let actual = parser.parse((input, interfaces)).unwrap();
+        let actual = parser.parse(input, (interfaces,)).unwrap();
         assert_eq!(actual, vec![]);
     }
 
@@ -219,7 +219,7 @@ mod tests {
         "};
         let interfaces = &[];
 
-        let actual = parser.parse((input, interfaces)).unwrap();
+        let actual = parser.parse(input, (interfaces,)).unwrap();
         assert_eq!(actual, vec![
             PPPoEClientSession {
                 user: "user01".to_string(),
@@ -286,7 +286,7 @@ mod tests {
             },
         ];
 
-        let actual = parser.parse((input, interfaces)).unwrap();
+        let actual = parser.parse(input, (interfaces,)).unwrap();
         assert_eq!(actual, vec![
             PPPoEClientSession {
                 user: "user01".to_string(),
@@ -353,7 +353,7 @@ mod tests {
             },
         ];
 
-        let actual = parser.parse((input, interfaces)).unwrap();
+        let actual = parser.parse(input, (interfaces,)).unwrap();
         assert_eq!(actual, vec![
             PPPoEClientSession {
                 user: "user01".to_string(),

--- a/src/infrastructure/cmd/parser/version.rs
+++ b/src/infrastructure/cmd/parser/version.rs
@@ -19,10 +19,10 @@ use crate::{
 pub struct VersionParser;
 
 impl Parser for VersionParser {
-    type Input<'a> = &'a str;
+    type Context<'a> = ();
     type Item = VersionResult;
 
-    fn parse(&self, input: Self::Input<'_>) -> anyhow::Result<Self::Item> {
+    fn parse(&self, input: &str, _context: ()) -> anyhow::Result<Self::Item> {
         parse_version(input)
             .finish()
             .map(|(_, version)| version)
@@ -106,7 +106,7 @@ mod tests {
         let parser = VersionParser;
         let input = "";
 
-        assert!(parser.parse(input).is_err());
+        assert!(parser.parse(input, ()).is_err());
     }
 
     #[test]
@@ -122,7 +122,7 @@ mod tests {
             Uptime:       01:00:00 up  1:00,  1 user,  load average: 1.00, 1.00, 1.00
         "};
 
-        let actual = parser.parse(input).unwrap();
+        let actual = parser.parse(input, ()).unwrap();
         assert_eq!(actual, Version {
             version: "v2.0.6".to_string(),
             build_id: "5208541".to_string(),


### PR DESCRIPTION
As `Parser` only accepts `&str` as its input, its lifetime does not necessarily have to be generic. This PR changes the arguments that `Parser::parse()` accepts and introduces a new generic associated type whose lifetime parameter is `'static` most of the time.