### PR TITLE
Use rust-toolchain@1.71 since MIPS GNU targets are moved to tier 3

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,8 +20,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      # TODO: Use Rust 1.71 since MIPS GNU targets no longer receive Tier 2 support.
+      # https://github.com/rust-lang/compiler-team/issues/648
+      # https://github.com/cross-rs/cross/issues/1319
       - name: Set up rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.71
         with:
           targets: ${{ matrix.target.name }}
       - name: Set up cross

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      # TODO: Use Rust 1.71 since MIPS GNU targets no longer receive Tier 2 support.
+      # https://github.com/rust-lang/compiler-team/issues/648
+      # https://github.com/cross-rs/cross/issues/1319
       - name: Set up rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.71
       - name: Test
         run: |
           cargo test --all
@@ -29,8 +32,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      # TODO: Use Rust 1.71 since MIPS GNU targets no longer receive Tier 2 support.
+      # https://github.com/rust-lang/compiler-team/issues/648
+      # https://github.com/cross-rs/cross/issues/1319
       - name: Set up rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.71
         with:
           targets: ${{ matrix.target.name }}
       - name: Set up cross


### PR DESCRIPTION
This PR (hopefully) temporarily sticks to Rust 1.71 since MIPS GNU targets no longer receive Tier 2 support.