### PR TITLE
Use build-std as MIPS GNU targets are now tier 3

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,11 +23,13 @@ jobs:
       - name: Set up rust
         uses: dtolnay/rust-toolchain@nightly
       - name: Set up cross
-        run: |
-          cargo install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
       - name: Set up cargo-deb
-        run: |
-          cargo install cargo-deb
+        uses: taiki-e/cache-cargo-install-action@v1
+        with:
+          tool: cargo-deb
       - name: Build
         run: |
           cross build --release --target=${{ matrix.target.name }} ${{ join(matrix.target.args, ' ') }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,13 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      # TODO: Use Rust 1.71 since MIPS GNU targets no longer receive Tier 2 support.
-      # https://github.com/rust-lang/compiler-team/issues/648
-      # https://github.com/cross-rs/cross/issues/1319
       - name: Set up rust
-        uses: dtolnay/rust-toolchain@1.71
-        with:
-          targets: ${{ matrix.target.name }}
+        uses: dtolnay/rust-toolchain@nightly
       - name: Set up cross
         run: |
           cargo install cross

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      # TODO: Use Rust 1.71 since MIPS GNU targets no longer receive Tier 2 support.
-      # https://github.com/rust-lang/compiler-team/issues/648
-      # https://github.com/cross-rs/cross/issues/1319
       - name: Set up rust
-        uses: dtolnay/rust-toolchain@1.71
+        uses: dtolnay/rust-toolchain@nightly
       - name: Test
         run: |
           cargo test --all
@@ -32,13 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      # TODO: Use Rust 1.71 since MIPS GNU targets no longer receive Tier 2 support.
-      # https://github.com/rust-lang/compiler-team/issues/648
-      # https://github.com/cross-rs/cross/issues/1319
       - name: Set up rust
-        uses: dtolnay/rust-toolchain@1.71
-        with:
-          targets: ${{ matrix.target.name }}
+        uses: dtolnay/rust-toolchain@nightly
       - name: Set up cross
         run: |
           cargo install cross

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,9 @@ jobs:
       - name: Set up rust
         uses: dtolnay/rust-toolchain@nightly
       - name: Set up cross
-        run: |
-          cargo install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
       - name: Build
         run: |
           cross build --release --target=${{ matrix.target.name }} ${{ join(matrix.target.args, ' ') }}

--- a/Cross.toml
+++ b/Cross.toml
@@ -14,6 +14,7 @@ pre-build = [
 
 [target.mipsel-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/mipsel-unknown-linux-gnu"
+build-std = true
 env.passthrough = [
     "RUSTFLAGS=-C strip=symbols",
     "OPENSSL_DIR=/usr/mipsel-linux-gnu",
@@ -21,6 +22,7 @@ env.passthrough = [
 
 [target.mips-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/mips-unknown-linux-gnu"
+build-std = true
 env.passthrough = [
     "RUSTFLAGS=-C strip=symbols",
     "OPENSSL_DIR=/usr/mips-linux-gnu",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Prometheus exporter for EdgeRouter BGP, DDNS, Load Balancers, and PPPoE sessio
 
 For development, the following dependencies are required:
 
-- [rustup](https://rustup.rs/)
+- [rustup](https://rustup.rs/) (nightly toolchain is required for [build-std](https://doc.rust-lang.org/cargo/reference/unstable.html#build-std))
 - [cross](https://github.com/cross-rs/cross)
 - openssl (e.g. libssl-dev, openssl, or openssl-devel)
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
Closes #354.