### PR TITLE
Disable HTTP/2 due to COMPRESSION_ERROR on client side

### DIFF
--- a/src/application/server.rs
+++ b/src/application/server.rs
@@ -7,7 +7,7 @@ use hyper::server::{conn::AddrIncoming, Server};
 use {
     hyper::server::conn::Http,
     notify::Watcher,
-    openssl::ssl::{self, AlpnError, SslContext, SslFiletype, SslMethod},
+    openssl::ssl::{SslContext, SslFiletype, SslMethod},
     tls_listener::TlsListener,
     tokio::{
         sync::mpsc::unbounded_channel,
@@ -87,10 +87,6 @@ fn acceptor(tls_cert: &str, tls_key: &str) -> anyhow::Result<SslContext> {
     builder
         .set_private_key_file(tls_key, SslFiletype::PEM)
         .context("error loading TLS private key")?;
-    builder
-        .set_alpn_select_callback(|_, client| {
-            ssl::select_next_proto(b"\x02h2\x08http/1.1", client).ok_or(AlpnError::NOACK)
-        });
 
     Ok(builder.build())
 }


### PR DESCRIPTION
Not exactly sure about why it fails but `GET /metrics` has failed due to `COMPRESSION_ERROR` on client side since nightly-2023-08-09 when it uses HTTP/2.